### PR TITLE
Simplifying Debian dependency handling code.

### DIFF
--- a/src/platforms/debian.py
+++ b/src/platforms/debian.py
@@ -7,19 +7,8 @@ import subprocess
 
 # this will do updates and installations
 def base_install_modules(module_name):
-
-    # if there is a , theres multiple modules
-    if "," in module_name:
-        module_name = module_name.split(",")
-        # this will combine everything
-        combined_modules = ""
-        # iterate through tuple
-        for modules in module_name:
-            combined_modules = combined_modules + " " + modules
-
-        subprocess.Popen("apt-get --force-yes -y install %s" % (combined_modules), shell=True).wait()
-
-    else:
-        # if its just one module
-        if len(module_name) > 1:
-            subprocess.Popen("apt-get --force-yes -y install " + module_name, shell=True).wait()
+    
+    # will work for 1 or more space- or comma-separated modules
+    modules = module_name.replace(",", " ")
+    command = "apt-get --force-yes -y install " + modules
+    subprocess.Popen(command, shell=True).wait()


### PR DESCRIPTION
It's better practice to combine the code that handles single item cases and multiple item cases when possible. It leaves less room for bugs and makes it easier to read.