### PR TITLE
Added module for Carlos Perez's (darkoperator) DNSRecon tool

### DIFF
--- a/modules/intelligence-gathering/dnsrecon.py
+++ b/modules/intelligence-gathering/dnsrecon.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+#####################################
+# Installation module for DNSRecon
+#####################################
+
+# AUTHOR OF MODULE NAME
+AUTHOR="Greg Hetrick (gchetrick)"
+
+# DESCRIPTION OF THE MODULE
+DESCRIPTION="This module will install/update dnsrecon - a dns enum tool by Carlos Parez"
+
+# INSTALL TYPE GIT, SVN, FILE DOWNLOAD
+# OPTIONS = GIT, SVN, FILE
+INSTALL_TYPE="GIT"
+
+# LOCATION OF THE FILE OR GIT/SVN REPOSITORY
+REPOSITORY_LOCATION="https://github.com/darkoperator/dnsrecon"
+
+# WHERE DO YOU WANT TO INSTALL IT
+INSTALL_LOCATION="dnsrecon"
+
+# DEPENDS FOR DEBIAN INSTALLS
+DEBIAN="python-dnspython,python-netaddr"
+
+# COMMANDS TO RUN AFTER
+AFTER_COMMANDS=""


### PR DESCRIPTION
Added a module for DNSRecon from Carlos Perez. There are 2 debian dependencies that seemed to test out fine. Tested in Kali. 