### PR TITLE
Add module for installing King Phisher

### DIFF
--- a/modules/exploitation/king_phisher.py
+++ b/modules/exploitation/king_phisher.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+######################################
+# Installation module for King Phisher
+######################################
+
+# AUTHOR OF MODULE NAME
+AUTHOR="Spencer McIntyre (@zeroSteiner)"
+
+# DESCRIPTION OF THE MODULE
+DESCRIPTION="This module will install/update the King Phisher phishing campaign toolkit"
+
+# INSTALL TYPE GIT, SVN, FILE DOWNLOAD
+# OPTIONS = GIT, SVN, FILE
+INSTALL_TYPE="GIT"
+
+# LOCATION OF THE FILE OR GIT/SVN REPOSITORY
+REPOSITORY_LOCATION="https://github.com/securestate/king-phisher/"
+
+# WHERE DO YOU WANT TO INSTALL IT
+INSTALL_LOCATION="king-phisher"
+
+# DEPENDS FOR DEBIAN INSTALLS
+DEBIAN="git"
+
+# COMMANDS TO RUN AFTER
+AFTER_COMMANDS="cd {INSTALL_LOCATION},easy_install -U pip,tools/install.sh"


### PR DESCRIPTION
This PR adds a module to the exploitation (not sure if that's the best place) directory for installing the [King Phisher](https://github.com/securestate/king-phisher) tool.

Tested on Ubuntu 14.04.