### PR TITLE
fix for issue #49, nmap.py doesn't properly build itself or ncat

### DIFF
--- a/modules/vulnerability-analysis/nmap.py
+++ b/modules/vulnerability-analysis/nmap.py
@@ -4,10 +4,10 @@
 #####################################
 
 # AUTHOR OF MODULE NAME
-AUTHOR="Mauro Risonho de Paula Assumpcao (firebits)"
+AUTHOR="Mauro Risonho de Paula Assumpcao (firebits), updated by Russ Swift (0xsalt)"
 
 # DESCRIPTION OF THE MODULE
-DESCRIPTION="This module will install/update Nmap (Network Mapper) is a security scanner"
+DESCRIPTION="This module will install/update Nmap (Network Mapper) and Ncat (Fyodor's Netcat)"
 
 # INSTALL TYPE GIT, SVN, FILE DOWNLOAD
 # OPTIONS = GIT, SVN, FILE
@@ -20,7 +20,7 @@ REPOSITORY_LOCATION="https://svn.nmap.org/nmap/"
 INSTALL_LOCATION="nmap-dev"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="subversion"
+DEBIAN="subversion,autoconf,build-essential,libssl-dev"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS=""
+AFTER_COMMANDS="cd {INSTALL_LOCATION},./configure,make,make install,cd {INSTALL_LOCATION}/ncat,./configure,make,make install"


### PR DESCRIPTION
Expected behavior: nmap and ncap will properly build and install when running
ptf> use modules/vulnerability-analysis/nmap
ptf:(modules/vulnerability-analysis/nmap)>install

Actual behavior: 
repository is checked out but nothing is built.

Also adds dependencies to work properly on Ubuntu 14.04-LTS Server

Fixed in github.com/0xsalt/ptf/. 

Branched my forked repo to isolate this bugfix & submit.