### PR TITLE
Added Medusa 2.2-rc1, built from git src

### DIFF
--- a/modules/vulnerability-analysis/install_ncpfs.sh
+++ b/modules/vulnerability-analysis/install_ncpfs.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+wget -c http://archive.ubuntu.com/ubuntu/pool/universe/n/ncpfs/libncp_2.2.6-8_amd64.deb -O /tmp/libncp_2.2.6-8_amd64.deb
+wget -c http://archive.ubuntu.com/ubuntu/pool/universe/n/ncpfs/libncp-dev_2.2.6-8_amd64.deb -O /tmp/libncp-dev_2.2.6-8_amd64.deb
+dpkg -i /tmp/libncp_2.2.6-8_amd64.deb
+dpkg -i /tmp/libncp-dev_2.2.6-8_amd64.deb

--- a/modules/vulnerability-analysis/medusa.py
+++ b/modules/vulnerability-analysis/medusa.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#####################################
+# Installation module for SET
+#####################################
+
+# AUTHOR OF MODULE NAME
+AUTHOR="Russ Swift (0xsalt)"
+
+# DESCRIPTION OF THE MODULE
+DESCRIPTION="This module will install/update Medusa, the Parallel Network Login Auditor. All modules enabled except AFP. Older (1.0) version of RDP without PtH support (so far)."
+
+# INSTALL TYPE GIT, SVN, FILE DOWNLOAD
+# OPTIONS = GIT, SVN, FILE
+INSTALL_TYPE="GIT"
+
+# LOCATION OF THE FILE OR GIT/SVN REPOSITORY
+REPOSITORY_LOCATION="https://github.com/jmk-foofus/medusa.git"
+
+# WHERE DO YOU WANT TO INSTALL IT
+INSTALL_LOCATION="medusa"
+
+# DEPENDS FOR DEBIAN INSTALLS
+DEBIAN="wget,git,build-essential,libpcre3-dev,libssl-dev,libpq5,libpq-dev,libssh2-1,libssh2-1-dev,libsvn-dev,libgnutls-dev,libfreerdp-dev,automake"
+
+# COMMANDS TO RUN AFTER
+AFTER_COMMANDS="bash ./modules/vulnerability-analysis/install_ncpfs.sh,cd {INSTALL_LOCATION},./configure,make,make install,medusa -d"
+
+# THIS WILL CREATE AN AUTOMATIC LAUNCHER FOR THE TOOL
+LAUNCHER="medusa"


### PR DESCRIPTION
Added foofus' Medusa, built from https://github.com/jmk-foofus/medusa

- All modules build except for AFP which needs a few more libraries & manual config. I've got this working but not in this pull request.
- Includes support for newly added RDP module. Uses freerdp.h 1.0 provided by Ubuntu so it's out of date and doesn't support PtH functionality. Will update to version 1.2 and submit another pull.

How would you like to handle additional dependencies for packages that might not be included by default in Ubuntu? For instance this tool requires libncp and libncp-dev, but they are not available in Ubuntu 14.04 repos, so I included a shell script to download them directly and install. Is this ok or do you prefer another method?

configure: *******************************************************
configure:     Medusa Module Build Summary
configure: 
configure:     AFP             ** Disabled **
configure:     CVS             Enabled
configure:     FTP             Enabled
configure:     HTTP            Enabled
configure:     IMAP            Enabled
configure:     MSSQL           Enabled
configure:     MYSQL           Enabled
configure:     NCP             Enabled
configure:     NNTP            Enabled
configure:     PCANYWHERE      Enabled
configure:     POP3            Enabled
configure:     POSTGRES        Enabled
configure:     RDP             Enabled
configure:     REXEC           Enabled
configure:     RLOGIN          Enabled
configure:     RSH             Enabled
configure:     SMBNT           Enabled
configure:     SMTP            Enabled
configure:     SMTP-VRFY       Enabled
configure:     SNMP            Enabled
configure:     SSH             Enabled
configure:     SVN             Enabled
configure:     TELNET          Enabled
configure:     VMAUTHD         Enabled
configure:     VNC             Enabled
configure:     WRAPPER         Enabled
configure:     WEB-FORM        Enabled
