### PR TITLE
updated ptf crackmapexec to build impacket libs from source

### DIFF
--- a/modules/vulnerability-analysis/crackmapexec.py
+++ b/modules/vulnerability-analysis/crackmapexec.py
@@ -4,7 +4,7 @@
 #####################################
 
 # AUTHOR OF MODULE NAME
-AUTHOR="David Kennedy (ReL1K)"
+AUTHOR="David Kennedy (ReL1K), updated by Russ Swift (0xsalt)"
 
 # DESCRIPTION OF THE MODULE
 DESCRIPTION="This module will install/update CrackMapExec - pentesters AD tool"
@@ -20,10 +20,10 @@ REPOSITORY_LOCATION="https://github.com/byt3bl33d3r/CrackMapExec"
 INSTALL_LOCATION="crackmapexec"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="python-impacket,python-gevent,python-netaddr"
+DEBIAN="python-dev,python-pip"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS=""
+AFTER_COMMANDS="cd {INSTALL_LOCATION},pip install --upgrade -r requirements.txt"
 
 # AUTOMATIC LAUNCH
 LAUNCHER="crackmapexec"


### PR DESCRIPTION
<pre>
# Expected behavior: crackmapexec will build impacket and other libraries from source

# Actual behavior:
impacket libs are not built from source and some required libs are missing

# Error message after running "install" in ptf and then trying to launch crackmapexec:

# which crackmapexec
/usr/local/bin/crackmapexec
# crackmapexec
Traceback (most recent call last):
  File "./crackmapexec.py", line 15, in <module>
    from impacket import smbserver, ntlm, winregistry  
ImportError: cannot import name winregistry

# Also adds dependencies to work on Ubuntu 14.04-LTS Server

# Fixed in github.com/0xsalt/ptf/crackmapexec-updatebuild

# Submitting pull request
</pre>