### PR TITLE
post-explotation/empire: removing echo new line from after command.

### DIFF
--- a/modules/post-exploitation/empire.py
+++ b/modules/post-exploitation/empire.py
@@ -26,7 +26,7 @@ DEBIAN="python-m2crypto, python-crypto"
 FEDORA="git,m2crypto,python-crypto"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},cd setup,echo -e '\n' | ./install.sh"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},cd setup,./install.sh"
 
 # DONT RUN AFTER COMMANDS ON UPDATE
 BYPASS_UPDATE=NO


### PR DESCRIPTION
It breaks on Debian based systems if apt-get needs confirmation. apt-get ends up getting the new line, which aborts the install of packages and then the post install script fails. Example below.
```
[*] Sending after command: echo -e '\n' | ./install.sh
Reading package lists... Done
Building dependency tree       
Reading state information... Done
python-pip is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 3 not upgraded.
Reading package lists... Done
Building dependency tree       
Reading state information... Done
python-dev is already the newest version.
python-dev set to manually installed.
0 upgraded, 0 newly installed, 0 to remove and 3 not upgraded.
Reading package lists... Done
Building dependency tree       
Reading state information... Done
python-m2crypto is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 3 not upgraded.
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following extra packages will be installed:
  swig2.0
Suggested packages:
  swig-doc swig-examples swig2.0-examples swig2.0-doc
The following NEW packages will be installed:
  swig swig2.0
0 upgraded, 2 newly installed, 0 to remove and 3 not upgraded.
Need to get 1,436 kB of archives.
After this operation, 4,589 kB of additional disk space will be used.
Do you want to continue? [Y/n] Abort.
Requirement already satisfied (use --upgrade to upgrade): pycrypto in /usr/lib/python2.7/dist-packages
Collecting iptools
  Downloading iptools-0.6.1.tar.gz
Building wheels for collected packages: iptools
  Running setup.py bdist_wheel for iptools
  Stored in directory: /root/.cache/pip/wheels/dc/95/32/f099d42988c096a4aa7e6a5dc11f0eddb377c86964933f1006
Successfully built iptools
Installing collected packages: iptools
Successfully installed iptools-0.6.1
Collecting pydispatcher
  Downloading PyDispatcher-2.0.5.tar.gz
Building wheels for collected packages: pydispatcher
  Running setup.py bdist_wheel for pydispatcher
  Stored in directory: /root/.cache/pip/wheels/83/19/da/6046a82324db0ed07ba3f480aa7a14a8c94f33de8a15ba6654
Successfully built pydispatcher
Installing collected packages: pydispatcher
Successfully installed pydispatcher-2.0.5

 [>] Enter server negotiation password, enter for random generation: Traceback (most recent call last):
  File "./setup_database.py", line 17, in <module>
    choice = raw_input("\n [>] Enter server negotiation password, enter for random generation: ")
EOFError: EOF when reading a line
```