### PR TITLE
Add dnscat2 application to post-exploitation

### DIFF
--- a/modules/post-exploitation/dnscat2.py
+++ b/modules/post-exploitation/dnscat2.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+#####################################
+# Installation module for dnscat2
+#####################################
+
+# AUTHOR OF MODULE NAME
+AUTHOR="Jens Muecke (ryd)"
+
+# DESCRIPTION OF THE MODULE
+DESCRIPTION="This module will install/update dnscat2"
+
+# INSTALL TYPE GIT, SVN, FILE DOWNLOAD
+# OPTIONS = GIT, SVN, FILE
+INSTALL_TYPE="GIT"
+
+# LOCATION OF THE FILE OR GIT/SVN REPOSITORY
+REPOSITORY_LOCATION="https://github.com/iagox86/dnscat2.git"
+
+# WHERE DO YOU WANT TO INSTALL IT
+INSTALL_LOCATION="dnscat2"
+
+# DEPENDS FOR DEBIAN INSTALLS
+DEBIAN="ruby ruby-dev git-core build-essential make"
+
+# DEPENDS FOR FEDORA INSTALLS
+FEDORA="git,make,gcc,gcc-c++,ruby-irb,rubygems,rubygem-bundler,ruby-devel,git"
+
+# COMMANDS TO RUN AFTER
+AFTER_COMMANDS="cd {INSTALL_LOCATION}/server,bundle install"
+
+# THIS WILL CREATE AN AUTOMATIC LAUNCHER FOR THE TOOL
+LAUNCHER=""


### PR DESCRIPTION
Modules install DNS server for dns tunnel

* require dns nameserver configuration
* require to compile client (make or download)
* server require ruby env snf bundler
* run with "cd server; ryby ./dnscat2.rb <domain>" and wait for sessions