### PR TITLE
Remove the -f option from CPAN

### DIFF
--- a/modules/intelligence-gathering/fierce.py
+++ b/modules/intelligence-gathering/fierce.py
@@ -26,7 +26,7 @@ DEBIAN="perl"
 FEDORA="git,perl,perl-CPAN"
 
 # COMMANDS TO RUN AFTER 
-AFTER_COMMANDS="export PERL_MM_USE_DEFAULT=1,export PERL_EXTUTILS_AUTOINSTALL='--defaultdeps',cpan -fi strict Net::hostent Net::DNS IO::Socket Socket Getopt::Long"
+AFTER_COMMANDS="export PERL_MM_USE_DEFAULT=1,export PERL_EXTUTILS_AUTOINSTALL='--defaultdeps',cpan -i strict Net::hostent Net::DNS IO::Socket Socket Getopt::Long"
 
 # create a launcher
 LAUNCHER="fierce"

--- a/src/framework.py
+++ b/src/framework.py
@@ -315,7 +315,7 @@ def use_module(module, all_trigger):
 
                 # if we are using wget
                 if install_type.lower() == "wget":
-                    print_status("WGET was the selected method for installation because it plays better that curl -l with Sourceforge.")
+                    print_status("WGET was the selected method for installation because it plays better than curl -l with Sourceforge.")
                     proc = subprocess.Popen("cd %s && wget -q %s" % (install_location, repository_location), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True).wait()
                     print_status("Finished Installing! Enjoy the tool located under: " + install_location)
                     after_commands(filename,install_location)


### PR DESCRIPTION
Removing the -f (force) option from the cpan command, so it will no longer attempt/force the install of perl from CPAN.