### PR TITLE
Update john.py

### DIFF
--- a/modules/post-exploitation/john.py
+++ b/modules/post-exploitation/john.py
@@ -26,8 +26,7 @@ DEBIAN="build-essential libnss3-dev libkrb5-dev libgmp-dev"
 FEDORA="git,make,automake,gcc,gcc-c++,kernel-devel,nss-devel,krb5-devel,gmp-devel,openssl,openssl-devel"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},cd src,./configure && make && make install,cd {INSTALL_LOCATION},cp run/john {INSTALL_LOCATION},echo #!/bin/sh > john.sh,echo ./john >> john.sh,chmod +x john.sh"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},cd src,./configure && make && make install,cd {INSTALL_LOCATION},cp -a run/* {INSTALL_LOCATION},rm -rf run/"
 
 # THIS WILL CREATE AN AUTOMATIC LAUNCHER FOR THE TOOL
 LAUNCHER=""
-


### PR DESCRIPTION
Copying everything in ./run/* to {INSTALL_DIRECTORY}. Had to be done this way, as john's --prefix (in configure) doesn't work properly. This will copy all the binaries, as well as general configuration files to {INSTALL_DIRECTORY}