### PR TITLE
Spiderfoot patch

### DIFF
--- a/modules/intelligence-gathering/spiderfoot.py
+++ b/modules/intelligence-gathering/spiderfoot.py
@@ -20,7 +20,10 @@ REPOSITORY_LOCATION="https://github.com/smicallef/spiderfoot.git"
 INSTALL_LOCATION="spiderfoot"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN=""
+DEBIAN="libxslt1-dev,libxml2-dev"
+
+# DEPENDS FOR FEDORA INSTALLS
+FEDORA="libxslt1-devel,libxml2-devel"
 
 # COMMANDS TO RUN AFTER
 AFTER_COMMANDS="pip install lxml netaddr M2Crypto cherrypy mako"

--- a/modules/intelligence-gathering/xdotool.py
+++ b/modules/intelligence-gathering/xdotool.py
@@ -20,10 +20,10 @@ REPOSITORY_LOCATION="https://github.com/jordansissel/xdotool.git"
 INSTALL_LOCATION="xdotool"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="make,libx11-dev,libxtst-dev,libxkbcommon-dev"
+DEBIAN="make,libx11-dev,libxtst-dev"
 
 # DEPENDS FOR FEDORA INSTALLS
-FEDORA="make,libx11-devel,libxtst-devel,libxkbcommon-devel"
+FEDORA="make,libx11-devel,libxtst-devel"
 
 # COMMANDS TO RUN AFTER
 AFTER_COMMANDS="cd {INSTALL_LOCATION},make,make install"

--- a/modules/intelligence-gathering/xdotool.py
+++ b/modules/intelligence-gathering/xdotool.py
@@ -20,10 +20,10 @@ REPOSITORY_LOCATION="https://github.com/jordansissel/xdotool.git"
 INSTALL_LOCATION="xdotool"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="make,libx11-dev,libxtst-dev"
+DEBIAN="make,libx11-dev,libxtst-dev,libxkbcommon-dev"
 
 # DEPENDS FOR FEDORA INSTALLS
-FEDORA="make,libx11-devel,libxtst-devel"
+FEDORA="make,libx11-devel,libxtst-devel,libxkbcommon-devel"
 
 # COMMANDS TO RUN AFTER
 AFTER_COMMANDS="cd {INSTALL_LOCATION},make,make install"

--- a/modules/vulnerability-analysis/skipfish.py
+++ b/modules/vulnerability-analysis/skipfish.py
@@ -20,10 +20,10 @@ REPOSITORY_LOCATION="http://skipfish.googlecode.com/svn/trunk/"
 INSTALL_LOCATION="skipfish"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="gcc subversion libidn11-dev libssl-dev build-essential zlibc zlib-bin libidn11-dev libidn11"
+DEBIAN="gcc subversion libidn11-dev libssl-dev build-essential zlibc zlib-bin libidn11-dev libidn11 libpcre3-dev"
 
 # DEPENDS FOR FEDORA INSTALLS
-FEDORA="git,gcc,subversion,openssl-devel,make,automake,gcc,gcc-c++,kernel-devel,zlib,zlib-devel,libidn,libidn-devel"
+FEDORA="git,gcc,subversion,openssl-devel,make,automake,gcc,gcc-c++,kernel-devel,zlib,zlib-devel,libidn,libidn-devel pcre-devel"
 
 # COMMANDS TO RUN AFTER
 AFTER_COMMANDS="cd {INSTALL_LOCATION},make"

--- a/modules/vulnerability-analysis/skipfish.py
+++ b/modules/vulnerability-analysis/skipfish.py
@@ -23,7 +23,7 @@ INSTALL_LOCATION="skipfish"
 DEBIAN="gcc subversion libidn11-dev libssl-dev build-essential zlibc zlib-bin libidn11-dev libidn11 libpcre3-dev"
 
 # DEPENDS FOR FEDORA INSTALLS
-FEDORA="git,gcc,subversion,openssl-devel,make,automake,gcc,gcc-c++,kernel-devel,zlib,zlib-devel,libidn,libidn-devel pcre-devel"
+FEDORA="git,gcc,subversion,openssl-devel,make,automake,gcc,gcc-c++,kernel-devel,zlib,zlib-devel,libidn,libidn-devel,pcre-devel"
 
 # COMMANDS TO RUN AFTER
 AFTER_COMMANDS="cd {INSTALL_LOCATION},make"


### PR DESCRIPTION
Added dependencies needed to build and install spiderfoot.  The module would not compile without the now included development libraries (libxslt1-dev and libxml2-dev) installed.