### PR TITLE
Updates to get metasploit working

### DIFF
--- a/modules/exploitation/metasploit.py
+++ b/modules/exploitation/metasploit.py
@@ -20,7 +20,7 @@ REPOSITORY_LOCATION="https://github.com/rapid7/metasploit-framework"
 INSTALL_LOCATION="metasploit"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="ruby ruby-dev nmap git-core curl zlib1g-dev build-essential libpq5 libpq-dev libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common libffi-dev libpcap-dev autoconf postgresql libgmp-dev"
+DEBIAN="ruby2.2 ruby2.2-dev nmap git-core curl zlib1g-dev build-essential libpq5 libpq-dev libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev software-properties-common libffi-dev libpcap-dev autoconf postgresql libgmp-dev"
 
 # DEPENDS FOR FEDORA INSTALLS
 FEDORA="git,make,automake,gcc,gcc-c++,kernel-devel,postgresql-server,postgresql-devel,libpcap-devel,sqlite-devel,ruby-irb,rubygems,rubygem-nokogiri,rubygem-ffi,rubygem-bigdecimal,rubygem-rake,rubygem-i18n,rubygem-bundler,ruby-devel,sqlite,rubygem-sqlite3,git,libxml2-devel,patch"


### PR DESCRIPTION
This fixes a bug #128 where metasploit fails to work after a full install.

Previously ruby 1.9.3 is installed, but metasploit requires 2.x