### PR TITLE
unzip dependency for sslyze

### DIFF
--- a/modules/vulnerability-analysis/sslyze.py
+++ b/modules/vulnerability-analysis/sslyze.py
@@ -20,13 +20,13 @@ REPOSITORY_LOCATION="https://github.com/nabla-c0d3/sslyze.git"
 INSTALL_LOCATION="sslyze"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN=""
+DEBIAN="unzip"
 
 # DEPENDS FOR FEDORA INSTALLS
-FEDORA=""
+FEDORA="unzip"
 
 # DEPENDS FOR ARCHLINUX INSTALLS
-ARCHLINUX=""
+ARCHLINUX="unzip"
 
 # COMMANDS TO RUN AFTER
 AFTER_COMMANDS="cd {INSTALL_LOCATION}, wget https://github.com/nabla-c0d3/sslyze/releases/download/release-0.12/sslyze-0_12-linux64.zip, unzip sslyze-0_12-linux64.zip && rm -rf sslyze-0_12-linux64.zip, mv sslyze/nassl ., rm -rf sslyze"


### PR DESCRIPTION
The sslyze package is downloaded as a zip file.  Adding the unzip package dependency to allow sslyze to be installed.