### PR TITLE
python-pycurl needed for WFUZZ

### DIFF
--- a/modules/vulnerability-analysis/wfuzz.py
+++ b/modules/vulnerability-analysis/wfuzz.py
@@ -20,10 +20,10 @@ REPOSITORY_LOCATION="https://github.com/xmendez/wfuzz.git"
 INSTALL_LOCATION="wfuzz"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="git"
+DEBIAN="git python-pycurl"
 
 # DEPENDS FOR FEDORA INSTALLS
-FEDORA="git"
+FEDORA="git python-pycurl"
 
 # DEPENDS FOR ARCHLINUX INSTALLS
 ARCHLINUX=""


### PR DESCRIPTION
wfuzz requires the pycurl module to function.  Added dependency for both Fedora and Debian.