### PR TITLE
updates for metasploit

### DIFF
--- a/modules/exploitation/metasploit.py
+++ b/modules/exploitation/metasploit.py
@@ -26,7 +26,7 @@ DEBIAN="ruby2.2 ruby2.2-dev nmap git-core curl zlib1g-dev build-essential libpq5
 FEDORA="git,make,automake,gcc,gcc-c++,kernel-devel,postgresql-server,postgresql-devel,libpcap-devel,sqlite-devel,ruby-irb,rubygems,rubygem-nokogiri,rubygem-ffi,rubygem-bigdecimal,rubygem-rake,rubygem-i18n,rubygem-bundler,ruby-devel,sqlite,rubygem-sqlite3,git,libxml2-devel,patch"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},gem outdated,gem update,gem install rails,gem install bundler,bundle install,cd /usr/local/bin,gem outdated,gem update,gem install rails,gem install bundler,bundle install,cd {INSTALL_LOCATION},gem install bundler,bundler install,bundle install"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},gem outdated,gem update,gem install rails,gem install bundler,bundle install,cd /usr/local/bin,gem outdated,gem update,gem install rails,gem install bundler,bundle install,cd {INSTALL_LOCATION},gem install bundler,bundler install,bundle install,ln -s /pentest/exploitation/metasploit/msfconsole /usr/local/bin/msfconsole"
 
 # THIS WILL CREATE AN AUTOMATIC LAUNCHER FOR THE TOOL
-LAUNCHER="msfconsole,msfbinscan,msfd,msfelfscan,msfmachscan,msfpescan,msfrop,msfrpc,msfrpcd,msfupdate,msfvenom"
+LAUNCHER="msfbinscan,msfd,msfelfscan,msfmachscan,msfpescan,msfrop,msfrpc,msfrpcd,msfupdate,msfvenom"

--- a/modules/intelligence-gathering/discover.py
+++ b/modules/intelligence-gathering/discover.py
@@ -20,7 +20,7 @@ REPOSITORY_LOCATION="https://github.com/leebaird/discover.git"
 INSTALL_LOCATION="discover"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="whois, traceroute, whatweb, arp-scan xdotool"
+DEBIAN="whois, traceroute, whatweb, arp-scan"
 
 # COMMANDS TO RUN AFTER 
 AFTER_COMMANDS=""

--- a/src/core.py
+++ b/src/core.py
@@ -316,7 +316,7 @@ def launcher(filename, install_location):
                 # if we found filetype
                 if point != "":
                     filewrite = file("/usr/local/bin/" + launchers, "w")
-                    filewrite.write('#!/bin/sh\ncd %s\nchmod +x %s\n%s "$*"' % (install_location,file_point,point))
+                    filewrite.write('#!/bin/sh\ncd %s\nchmod +x %s\n%s $*' % (install_location,file_point,point))
                     filewrite.close()
                     subprocess.Popen("chmod +x /usr/local/bin/%s" % (launchers), shell=True).wait()
                     print_status("Created automatic launcher, you can run the tool from anywhere by typing: " + launchers)


### PR DESCRIPTION
Removed quotes from the $* environment variable in 'core.py' for the launchers, as it broke other tools when trying to fix the msfconsole -x option.

Removed msfconsole from launcher in metasploit.py and added an after command to create a symlink.

Removed 'xdotool' from discover.py since it has its own PTF module.