### PR TITLE
Additional Requirements

### DIFF
--- a/modules/exploitation/kingphisher.py
+++ b/modules/exploitation/kingphisher.py
@@ -20,7 +20,7 @@ REPOSITORY_LOCATION="https://github.com/securestate/king-phisher/"
 INSTALL_LOCATION="king-phisher"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="git"
+DEBIAN="git,python-mpltoolkits.basemap,python-mpltoolkits.basemap-data"
 
 # DEPENDS FOR FEDORA INSTALLS
 FEDORA="git"


### PR DESCRIPTION
Added additional requirements for Debian based distros (python-mpltoolkits.basemap, python-mpltoolkits.basemap-data).  Found that tools/install.sh bombs without them when trying to install pip packages listed in requirements.txt and requirements3.txt.