### PR TITLE
Moved msfconsole symlink to LAUNCHER

### DIFF
--- a/modules/exploitation/metasploit.py
+++ b/modules/exploitation/metasploit.py
@@ -26,7 +26,7 @@ DEBIAN="git ruby ruby2.3 ruby2.3-dev nmap git-core curl zlib1g-dev build-essenti
 FEDORA="git,make,automake,gcc,gcc-c++,kernel-devel,postgresql-server,postgresql-devel,libpcap-devel,sqlite-devel,ruby-irb,rubygems,rubygem-nokogiri,rubygem-ffi,rubygem-bigdecimal,rubygem-rake,rubygem-i18n,rubygem-bundler,ruby-devel,sqlite,rubygem-sqlite3,git,libxml2-devel,patch"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},gem outdated,gem update,gem install rails,gem install bundler,bundle install,cd /usr/local/bin,gem outdated,gem update,gem install rails,gem install bundler,bundle install,cd {INSTALL_LOCATION},gem install bundler,bundler install,bundle install,ln -s /pentest/exploitation/metasploit/msfconsole /usr/local/bin/msfconsole"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},gem outdated,gem update,gem install rails,gem install bundler,bundle install,cd /usr/local/bin,gem outdated,gem update,gem install rails,gem install bundler,bundle install,cd {INSTALL_LOCATION},gem install bundler,bundler install,bundle install"
 
 # THIS WILL CREATE AN AUTOMATIC LAUNCHER FOR THE TOOL
-LAUNCHER="msfbinscan,msfd,msfelfscan,msfmachscan,msfpescan,msfrop,msfrpc,msfrpcd,msfupdate,msfvenom"
+LAUNCHER="msfconsole,msfbinscan,msfd,msfelfscan,msfmachscan,msfpescan,msfrop,msfrpc,msfrpcd,msfupdate,msfvenom"


### PR DESCRIPTION
Moved creation of msfconsole symlink from AFTER_COMMANDS to LAUNCHER, to stop it using a hardcoded installation path.