### PR TITLE
check to see if install_location has files to determine if git pull should be run.

### DIFF
--- a/src/framework.py
+++ b/src/framework.py
@@ -373,8 +373,8 @@ def use_module(module, all_trigger):
 
                     # if we are using git
                     if install_type.lower() == "git":
-                        # if we are updating
-                        if os.path.isdir(install_location):
+                        # if there are files in the install_location, we'll update.
+                        if os.listdir(install_location):
                             print_status("Installation already exists, going to git pull then run after commands..")
                             subprocess.Popen("cd %s;git pull" % (install_location), stderr=subprocess.PIPE, shell=True).wait()
                             print_status("Finished updating the tool located in:" + install_location)


### PR DESCRIPTION
There's an issue with [the recent check to see if a programs folder exists](https://github.com/trustedsec/ptf/blob/master/src/framework.py#L377) to determine if "git pull" or "git clone" should be run.  [The step above that](https://github.com/trustedsec/ptf/blob/master/src/framework.py#L369) creates the folder for the program, so the check is always going to be true, essentially breaking new installs for tools when using git.

This PR fixes this by changing the check to use `os.listdir` instead of `os.path.isdir`. os.listdir will return false if the directory is empty (and true if it is not). 