### PR TITLE
Add dependency for nikto

### DIFF
--- a/modules/vulnerability-analysis/nikto.py
+++ b/modules/vulnerability-analysis/nikto.py
@@ -20,10 +20,10 @@ REPOSITORY_LOCATION="https://github.com/sullo/nikto"
 INSTALL_LOCATION="nikto"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="perl"
+DEBIAN="perl,libnet-ssleay-perl"
 
 # DEPENDS FOR FEDORA INSTALLS
-FEDORA="git,perl"
+FEDORA="git,perl,perl-Net-SSLeay"
 
 # COMMANDS TO RUN AFTER
 AFTER_COMMANDS="cd {INSTALL_LOCATION},cp -R program/* ./"


### PR DESCRIPTION
Nikto is depending on SSLeay perl module to use HTTPS/SSL urls. This patch add
the dependency for debian and fedora