### PR TITLE
Fixed missing '/' within IGNORE_THESE_MODULES

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ You can also just run ./ptf --update-all and it will automatically update everyt
 
 ### IGNORE Modules or Categories
 
-The "IGNORE_THESE_MODULES=" config option can be found under config/ptf.config in the PTF root directory. This will ignore modules and not install them - everything is comma separated and based on name - example: modules/exploitation/metasploit,modules/exploitation/set or entire module categories, like modules/code-audit/*,/modules/reporting/*
+The "IGNORE_THESE_MODULES=" config option can be found under config/ptf.config in the PTF root directory. This will ignore modules and not install them - everything is comma separated and based on name - example: modules/exploitation/metasploit,modules/exploitation/set or entire module categories, like /modules/code-audit/*,/modules/reporting/*

--- a/config/ptf.config
+++ b/config/ptf.config
@@ -11,5 +11,5 @@ LOG_PATH="src/logs/ptf.log"
 ### When using update_all, also update all of your debian/ubuntu modules
 AUTO_UPDATE="ON"
 
-### This will ignore modules and not install them - everything is comma separated and based on name - example: modules/exploitation/metasploit,modules/exploitation/set or entire module categories, like modules/code-audit/*,/modules/reporting/*
+### This will ignore modules and not install them - everything is comma separated and based on name - example: modules/exploitation/metasploit,modules/exploitation/set or entire module categories, like /modules/code-audit/*,/modules/reporting/*
 IGNORE_THESE_MODULES=""


### PR DESCRIPTION
Hi Dave,

Related to issue 205.
I was working on excluding modules being installed.

I noticed in the readme, the syntax is incorrect. However the Readme that is downloaded verses what shows on the github page is different. However I have added a missing '/' to the downloaded Readme and ptf.config file.

Cheers,
Haydn