### PR TITLE
Correct missing comma in post-commands

### DIFF
--- a/modules/exploitation/metasploit.py
+++ b/modules/exploitation/metasploit.py
@@ -26,7 +26,7 @@ DEBIAN="autoconf bison build-essential curl git-core libapr1 libaprutil1 libcurl
 FEDORA=""
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},mv msfupdate.erb msfinstall,chmod 755 msfinstall,./msfinstall,rm msfinstall,update-rc.d postgresql enable, chmod +x {PTF_LOCATION}/modules/exploitation/msfdb.sh,sh {PTF_LOCATION}/modules/exploitation/msfdb.sh,mkdir /root/.msf4 cp /opt/database.yml /root/.msf4/,rm -rf /pentest/exploitation/metasploit 2> /dev/null,rm -rf /usr/local/bin/msf*"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},mv msfupdate.erb msfinstall,chmod 755 msfinstall,./msfinstall,rm msfinstall,update-rc.d postgresql enable, chmod +x {PTF_LOCATION}/modules/exploitation/msfdb.sh,sh {PTF_LOCATION}/modules/exploitation/msfdb.sh,mkdir /root/.msf4, cp /opt/database.yml /root/.msf4/,rm -rf /pentest/exploitation/metasploit 2> /dev/null,rm -rf /usr/local/bin/msf*"
 
 # THIS WILL CREATE AN AUTOMATIC LAUNCHER FOR THE TOOL
 LAUNCHER=""


### PR DESCRIPTION
No  comma resulted in a command line that tried: mkdir /root/.msf4 cp /opt/database.yml /root/.msf4

Added comma after the inital mkdir to separate into a separate mkdir and cp command.