### PR TITLE
Update discover depends & use wget for urlcrazy & goofile

### DIFF
--- a/modules/intelligence-gathering/discover.py
+++ b/modules/intelligence-gathering/discover.py
@@ -4,7 +4,7 @@
 #####################################
 
 # AUTHOR OF MODULE NAME
-AUTHOR="Martin Bos (purehate)"
+AUTHOR="Martin Bos (purehate) & Jason Ashton (jayw0k)"
 
 # DESCRIPTION OF THE MODULE
 DESCRIPTION="This module will install/update discover - an OSINT tool"
@@ -20,9 +20,9 @@ REPOSITORY_LOCATION="https://github.com/leebaird/discover.git"
 INSTALL_LOCATION="discover"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="git, whois, traceroute, whatweb, arp-scan, cutycapt, gnumeric"
+DEBIAN="git, whois, traceroute, whatweb, arp-scan, cutycapt, gnumeric, xml-twig-tools"
 
-# COMMANDS TO RUN AFTER 
+# COMMANDS TO RUN AFTER
 AFTER_COMMANDS="pip install urllib3[secure] --upgrade"
 
 # CREATE LAUNCHER

--- a/modules/intelligence-gathering/goofile.py
+++ b/modules/intelligence-gathering/goofile.py
@@ -11,10 +11,10 @@ DESCRIPTION="This module will install/update goofile - a Google Advanced Searche
 
 # INSTALL TYPE GIT, SVN, FILE DOWNLOAD
 # OPTIONS = GIT, SVN, FILE
-INSTALL_TYPE="FILE"
+INSTALL_TYPE="WGET"
 
 # LOCATION OF THE FILE OR GIT/SVN REPOSITORY
-REPOSITORY_LOCATION="https://goofile.googlecode.com/files/goofilev1.5.zip"
+REPOSITORY_LOCATION="https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/goofile/goofilev1.5.zip"
 
 # WHERE DO YOU WANT TO INSTALL IT
 INSTALL_LOCATION="goofile"
@@ -26,7 +26,7 @@ DEBIAN=""
 FEDORA=""
 
 # COMMANDS TO RUN AFTER 
-AFTER_COMMANDS="cd {INSTALL_LOCATION}, unzip goofilev1.5.zip && rm -rf goofilev1.5.zip, mv goofilev1.5/goofile.py ., rm -rf goofilev1.5"
+AFTER_COMMANDS="cd {INSTALL_LOCATION}, unzip goofilev1.5.zip, mv goofilev1.5/* ., rm -rf goofilev1.5/, rm goofilev1.5.zip"
 
 # create a launcher
 LAUNCHER="goofile"

--- a/modules/intelligence-gathering/urlcrazy.py
+++ b/modules/intelligence-gathering/urlcrazy.py
@@ -11,7 +11,7 @@ DESCRIPTION="This module will install/update urlcrazy (needed for discover)."
 
 # INSTALL TYPE GIT, SVN, FILE DOWNLOAD
 # OPTIONS = GIT, SVN, FILE
-INSTALL_TYPE="FILE"
+INSTALL_TYPE="WGET"
 
 # LOCATION OF THE FILE OR GIT/SVN REPOSITORY
 REPOSITORY_LOCATION="http://www.morningstarsecurity.com/downloads/urlcrazy-0.5.tar.gz"
@@ -26,6 +26,6 @@ DEBIAN=""
 FEDORA=""
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},make,make install"
+AFTER_COMMANDS="cd {INSTALL_LOCATION}, tar -xzvf urlcrazy-0.5.tar.gz, mv urlcrazy-0.5/* ., rm -rf urlcrazy-0.5/, rm urlcrazy-0.5.tar.gz, if [ ! -f tld.rb.bak ]; then cp tld.rb tld.rb.bak; grep -E '"bd"=>|"bn"=>|"br"=>' -v tld.rb > tld_tmp.rb; mv tld_tmp.rb tld.rb; fi"
 
 LAUNCHER="urlcrazy"


### PR DESCRIPTION
Update discover depends, use 'wget' for urlcrazy & goofile, added after commands for urlcrazy to correct errors in ruby script - since currently unsupported.