### PR TITLE
Added user-submitted module section and script to change network interface naming conventions back to earlier style

### DIFF
--- a/config/ptf.config
+++ b/config/ptf.config
@@ -12,4 +12,4 @@ LOG_PATH="src/logs/ptf.log"
 AUTO_UPDATE="ON"
 
 ### This will ignore modules and not install them - everything is comma separated and based on name - example: modules/exploitation/metasploit,modules/exploitation/set or entire module categories, like /modules/code-audit/*,/modules/reporting/*
-IGNORE_THESE_MODULES=""
+IGNORE_THESE_MODULES="/modules/user-submitted"

--- a/modules/user-submitted/old-interface-names.py
+++ b/modules/user-submitted/old-interface-names.py
@@ -7,7 +7,7 @@
 AUTHOR="BustedSec (Frank_Trezza)"
 
 # DESCRIPTION OF THE MODULE
-DESCRIPTION="This module will force an ubuntu or debian machine to use the old naming convention for network interfaces such as eth0 or wlan0 instead of the new convention introduced into udev in recent kernal versions (tested on ubuntu 15.10, 16.04, and debian 8.6.0")
+DESCRIPTION="This module will force an ubuntu or debian machine to use the old naming convention for network interfaces such as eth0 or wlan0 instead of the new convention introduced into udev in recent kernal versions (tested on ubuntu 15.10, 16.04, and debian 8.6.0"
 
 # INSTALL TYPE GIT, SVN, FILE DOWNLOAD
 # OPTIONS = GIT, SVN, FILE
@@ -26,7 +26,7 @@ DEBIAN=""
 FEDORA=""
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="perl src/confset.pl GRUB_CMDLINE_LINUX=\""net.ifnames=0 biosdevname=0\"" /etc/default/grub"
+AFTER_COMMANDS="perl src/confset.pl GRUB_CMDLINE_LINUX=\""net.ifnames=0 biosdevname=0\"" /etc/default/grub, update-grub"
 
 
 

--- a/modules/user-submitted/old-interface-names.py
+++ b/modules/user-submitted/old-interface-names.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+#####################################
+# Installation module for Old Interface Names
+#####################################
+
+# AUTHOR OF MODULE NAME
+AUTHOR="BustedSec (Frank_Trezza)"
+
+# DESCRIPTION OF THE MODULE
+DESCRIPTION="This module will force an ubuntu or debian machine to use the old naming convention for network interfaces such as eth0 or wlan0 instead of the new convention introduced into udev in recent kernal versions (tested on ubuntu 15.10, 16.04, and debian 8.6.0")
+
+# INSTALL TYPE GIT, SVN, FILE DOWNLOAD
+# OPTIONS = GIT, SVN, FILE
+INSTALL_TYPE="FILE"
+
+# LOCATION OF THE FILE OR GIT/SVN REPOSITORY
+REPOSITORY_LOCATION=""
+
+# WHERE DO YOU WANT TO INSTALL IT
+INSTALL_LOCATION=""
+
+# DEPENDS FOR DEBIAN INSTALLS
+DEBIAN=""
+
+# DEPENDS FOR FEDORA INSTALLS
+FEDORA=""
+
+# COMMANDS TO RUN AFTER
+AFTER_COMMANDS="perl src/confset.pl GRUB_CMDLINE_LINUX=\""net.ifnames=0 biosdevname=0\"" /etc/default/grub"
+
+
+

--- a/src/confset.pl
+++ b/src/confset.pl
@@ -1,0 +1,109 @@
+#!/usr/bin/perl
+
+use strict;
+
+my $scriptname = $0;
+my $separator = '=';
+my $whitespace = 0;
+
+my @files = ();
+my @namevalues = ();
+
+# read in the command line arguments
+for (my $i=0; $i<scalar(@ARGV); $i++){
+    my $arg = @ARGV[$i];
+    if ($arg =~ /^-/){
+        &printHelp(*STDOUT, 0) if ($arg eq "-h" or $arg eq "--help");
+        &printHelp(*STDERR, 1) if ($i+1 >= scalar(@ARGV));
+        my $opt = @ARGV[++$i];
+        if ($arg eq "-s" or $arg eq "--separator"){
+            $separator = $opt;
+        } elsif ($arg eq "-w" or $arg eq "--whitespace"){
+            $whitespace = 0;
+            $whitespace = 1 if ($opt =~ /1|t|y/);
+        } else {
+            &printHelp(*STDERR, 1);
+        }
+    } elsif ( -e $arg){
+        push(@files, $arg);
+    } else {
+        push(@namevalues, $arg);
+    }
+}
+
+# check the validity of the command line arguments
+if (scalar(@files) == 0){
+    print STDERR "ERROR: No files specified\n";
+    printHelp(*STDERR, 1);
+}
+
+if (scalar(@namevalues) == 0){
+    print STDERR "ERROR: No name value pairs specified\n";
+    printHelp(*STDERR, 1);
+}
+
+my $names = {};
+
+foreach my $namevalue (@namevalues){
+    my ($name, $value) = &splitnv($namevalue);
+    if ($name){
+        $names->{$name} = {"value",$value,"replaced",0};
+    } else {
+        print STDERR "ERROR: Argument not a file and contains no separator: $namevalue\n";
+        printHelp(*STDERR, 1);
+    }
+}
+
+# Do the modification to each conf file
+foreach my $file (@files){
+
+    # read in the entire file into memory
+    my $contents = "";
+    open FILE, $file or die $!;
+    while (my $line = <FILE>){
+        chomp $line;
+        my ($name, $value) = &splitnv($line);
+        # set matching lines to their new value
+        if ($names->{$name}){
+            $line = $name . $separator . $names->{$name}->{value};
+            $names->{$name}->{replaced} = 1;
+        }
+        $contents .= "$line\n";
+    }
+    close FILE or die $!;
+
+    # add any new lines that didn't already get set
+    foreach my $name (keys %$names){
+        if (!$names->{$name}->{replaced}){
+            $contents .= $name . $separator . $names->{$name}->{value}."\n";
+        }
+        # reset for next file
+        $names->{$name}->{replaced} = 0;
+    }
+
+    # overwrite the file
+    open FILE, ">$file" or die $!;
+    print FILE $contents;
+    close FILE or die $!;
+}
+
+# Print help message to the specified stream and exit with the specified value
+sub printHelp(){
+    my ($stream, $exit) = @_;
+    print $stream "Usage: $scriptname <options> name1=value1 name2=value2 file1.conf file2.conf\n";
+    print $stream "Options:\n";
+    print $stream "  -s --separator <value>        What comes between names and values (default =)\n";
+    print $stream "  -w --whitespace  <true|false> Allow space around names and values (default false)\n";
+    exit $exit;
+}
+
+# Split a string into a name and value using the global separator
+sub splitnv(){
+    my ($str) = @_;
+    my $ind = index($str, $separator);
+    return (0,0) if ($ind < 0);
+    my $name = substr($str, 0, $ind);
+    my $value = substr($str, $ind+length($separator));
+    $name =~ s/(^[ \t])*|([ \t])*$//g if ($whitespace);
+    return ($name, $value);
+}


### PR DESCRIPTION
I added a new section called user-submitted and set it to be ignored in the ptf config file so it doesn't force changes within on the entire PTF userbase who runs update\upgrade. The thought behind this is that there are certain changes that some users may not want but many might which can easily be configured through the framework. Rather then force anyone who runs an update_upgrade_all to get these kind of modules, instead we put them in a user-submitted folder which users can then install from manually. In the future, I would like to perhaps implement a flag within a module that if read would make it so it isn't run when UPDATE_UPGRADE_ALL is run so that optional modules can be set to not install but still kept within the normal folder structure. Any comments or criticisms welcome. Additionally, if this is an unwanted change I understand and will do my best to find another way to implement this. 