### PR TITLE
Copy cowpatty to /usr/bin

### DIFF
--- a/modules/password-recovery/cowpatty.py
+++ b/modules/password-recovery/cowpatty.py
@@ -23,7 +23,7 @@ INSTALL_LOCATION="cowpatty"
 DEBIAN="libssl-dev libpcap-dev"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},tar zxfv cowpatty-4.6.tgz,rm -rf *.tgz,cd cowpatty-4.6,make"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},tar zxfv cowpatty-4.6.tgz,rm -rf *.tgz,cd cowpatty-4.6,make,sudo cp cowpatty /usr/bin"
 
 # LAUNCHER
 LAUNCHER="cowpatty"


### PR DESCRIPTION
This fixes wifite not locating cowpatty. I missed copying cowpatty to the /usr/bin directory.