### PR TITLE
Add libxml2-utils dependency.

### DIFF
--- a/modules/intelligence-gathering/discover.py
+++ b/modules/intelligence-gathering/discover.py
@@ -20,7 +20,7 @@ REPOSITORY_LOCATION="https://github.com/leebaird/discover.git"
 INSTALL_LOCATION="discover"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="git, whois, traceroute, whatweb, arp-scan, cutycapt, gnumeric, xml-twig-tools"
+DEBIAN="git, whois, traceroute, whatweb, arp-scan, cutycapt, gnumeric, libxml2-utils, xml-twig-tools"
 
 # COMMANDS TO RUN AFTER
 AFTER_COMMANDS="pip install urllib3[secure] --upgrade"


### PR DESCRIPTION
Resolves the following errors during execution:

```
ARIN
     Email                (1/33)
./discover.sh: line 229: xmllint: command not found
./discover.sh: line 230: xmllint: command not found
     Names                (2/33)
grep: tmp: No such file or directory
     Networks             (3/33)
./discover.sh: line 254: xmllint: command not found
```