### PR TITLE
Fix typo in ipcrawl install module

### DIFF
--- a/modules/intelligence-gathering/ipcrawl.py
+++ b/modules/intelligence-gathering/ipcrawl.py
@@ -26,7 +26,7 @@ DEBIAN="git,gcc"
 FEDORA="git,gcc"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},gcc ipcrawl.c -o ipcrawl,chmod -x ipcrawl"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},gcc ipcrawl.c -o ipcrawl,chmod +x ipcrawl"
 
 # CREATE LAUNCHER
 LAUNCHER="ipcrawl"


### PR DESCRIPTION
Changed chmod -x ipcrawl to chmod +x ipcrawl.