### PR TITLE
aircrack-ng.py: Replace broken IEEE oui.txt link

### DIFF
--- a/modules/wireless/aircrackng.py
+++ b/modules/wireless/aircrackng.py
@@ -26,4 +26,4 @@ DEBIAN="libsqlite3-dev,libnl-3-dev,libnl-cli-3-dev"
 FEDORA="git,libsqlite3x-devel,libnl3-devel,libnl-genl-3-dev"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},make -j4,make strip,make install,airodump-ng-oui-update"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},make -j4,make strip,sed -i 's|http://standards-oui.ieee.org/oui.txt|http://linuxnet.ca/ieee/oui.txt|g' scripts/airodump-ng-oui-update,make install,airodump-ng-oui-update"


### PR DESCRIPTION
The IEEE link is often unavailable and breaks automated builds. Change was rejected upstream, to be fair: https://github.com/aircrack-ng/aircrack-ng/issues/103.

That said, Ubuntu 16.04 x64 at the very least doesn't include any copy of oui.txt, so I'm a little confused by the author's reply.