### PR TITLE
Update johntheripper.py: Revert AFTER_COMMANDS

### DIFF
--- a/modules/password-recovery/johntheripper.py
+++ b/modules/password-recovery/johntheripper.py
@@ -23,7 +23,7 @@ INSTALL_LOCATION="johntheripper"
 DEBIAN="git libgmp3-dev git lzip gcc-multilib make m4 mingw-w64"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION}src,./configure,make"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},cd src,./configure && make -j `nproc` && make install,cd {INSTALL_LOCATION},cp -a run/* {INSTALL_LOCATION},rm -rf run/"
 
 
 # DONT RUN AFTER COMMANDS ON UPDATE

--- a/modules/password-recovery/johntheripper.py
+++ b/modules/password-recovery/johntheripper.py
@@ -7,7 +7,7 @@
 AUTHOR="Martin Bos (@purehate_)"
 
 # DESCRIPTION OF THE MODULE
-DESCRIPTION="This module will install/update John the Ripper. The "bleeding-jumbo" branch - An CPU-based password recovery tool.This is not "official" John the Ripper code"
+DESCRIPTION="This module will install/update John the Ripper. The 'bleeding-jumbo' branch - An CPU-based password recovery tool.This is not 'official' John the Ripper code"
 
 # INSTALL TYPE GIT, SVN, FILE DOWNLOAD
 # OPTIONS = GIT, SVN, FILE

--- a/modules/wireless/aircrackng.py
+++ b/modules/wireless/aircrackng.py
@@ -20,7 +20,7 @@ REPOSITORY_LOCATION="https://github.com/aircrack-ng/aircrack-ng"
 INSTALL_LOCATION="aircrack-ng"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="libsqlite3-dev,libnl-3-dev,libnl-cli-3-dev"
+DEBIAN="libsqlite3-dev,libnl-3-dev,libnl-cli-3-dev,pkg-config"
 
 # DEPENDS FOR FEDORA INSTALLS
 FEDORA="git,libsqlite3x-devel,libnl3-devel,libnl-genl-3-dev"


### PR DESCRIPTION
Revert to 1c7d45b. This change was lost in moving johntheripper.py from a prior folder (6566bd3). 

This is also the first time I've suggested using backticks (for `nproc`). It worked in my local testing, but I could've missed an error message from `make`, I suppose.