### PR TITLE
Update hydra.py: Include dependency

### DIFF
--- a/modules/vulnerability-analysis/hydra.py
+++ b/modules/vulnerability-analysis/hydra.py
@@ -20,7 +20,7 @@ REPOSITORY_LOCATION="https://github.com/vanhauser-thc/thc-hydra.git"
 INSTALL_LOCATION="hydra"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="libssl-dev libssh-dev libidn11-dev libpcre3-dev libgtk2.0-dev libmysqlclient-dev libpq-dev libsvn-dev firebird-dev libncp-dev, ldap-utils"
+DEBIAN="libssl-dev libssh-dev libidn11-dev libpcre3-dev libgtk2.0-dev libmysqlclient-dev libpq-dev libsvn-dev firebird-dev libncp-dev ldap-utils ruby-dev"
 
 # DEPENDS FOR FEDORA INSTALLS
 FEDORA="openssl-devel pcre-devel ncpfs-devel postgresql-devel libssh-devel subversion-devel libncurses-devel"


### PR DESCRIPTION
The below error was the hint I needed: 

```
mkmf.rb can't find header files for ruby at /usr/lib/ruby/include/ruby.h
```