### PR TITLE
Update xdotool.py: Fix dependency typo

### DIFF
--- a/modules/intelligence-gathering/xdotool.py
+++ b/modules/intelligence-gathering/xdotool.py
@@ -20,7 +20,7 @@ REPOSITORY_LOCATION="https://github.com/jordansissel/xdotool.git"
 INSTALL_LOCATION="xdotool"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="git,make -j4,libx11-dev,libxtst-dev"
+DEBIAN="git,make,libx11-dev,libxtst-dev"
 
 # DEPENDS FOR FEDORA INSTALLS
 FEDORA="make,libx11-devel,libxtst-devel"


### PR DESCRIPTION
Some jerk ran a bad sed command in https://github.com/trustedsec/ptf/commit/5c3498ce010efa6172e964ec92ef00f901eeb8ac