### PR TITLE
Added creddump7 module

### DIFF
--- a/modules/post-exploitation/creddump7.py
+++ b/modules/post-exploitation/creddump7.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+#####################################
+# Installation module for Ruler
+#####################################
+
+# AUTHOR OF MODULE NAME
+AUTHOR="Jeff McJunkin"
+
+# DESCRIPTION OF THE MODULE
+DESCRIPTION="This module will install/update creddump7 - a standalone Python script to dump Windows credentials"
+
+# INSTALL TYPE GIT, SVN, FILE DOWNLOAD
+# OPTIONS = GIT, SVN, FILE
+INSTALL_TYPE="GIT"
+
+# LOCATION OF THE FILE OR GIT/SVN REPOSITORY
+REPOSITORY_LOCATION="https://github.com/Neohapsis/creddump7"
+
+# WHERE DO YOU WANT TO INSTALL IT
+INSTALL_LOCATION="creddump7"
+
+# DEPENDS FOR DEBIAN INSTALLS
+DEBIAN="git,python-crypto"
+
+# DEPENDS FOR FEDORA INSTALLS
+FEDORA="git,python-crypto"
+
+# COMMANDS TO RUN AFTER
+AFTER_COMMANDS=""
+
+# THIS WILL CREATE AN AUTOMATIC LAUNCHER FOR THE TOOL
+LAUNCHER="cachedump.py,lsadump.py,pwdump.py"
+
+BYPASS_UPDATES="NO"


### PR DESCRIPTION
Useful for cached domain credentials in particular, especially because apparently the Metasploit post-module is broken at the moment: https://github.com/rapid7/metasploit-framework/issues/8525 