### PR TITLE
changing cwd before using tool has adverse effects

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -380,8 +380,8 @@ def launcher(filename, install_location):
                 # if we found filetype
                 if point != "":
                     filewrite = open("/usr/local/bin/" + launchers, "w")
-                    filewrite.write('#!/bin/sh\ncd %s\nfind %s -executable || chmod +x %s\n%s $*\n' %
-                                    (install_location, file_point, file_point, point))
+                    filewrite.write('#!/bin/sh\n[ -e %s%s ] || chmod +x %s%s\n%s%s $*\n' %
+                                    (install_location, file_point, install_location, file_point, install_location, file_point))
                     filewrite.close()
                     subprocess.Popen("chmod +x /usr/local/bin/%s" %
                                      (launchers), shell=True).wait()


### PR DESCRIPTION
Proposed fix for #322. Changing directories before launching the tool messes up default behavior for some tools.

Outputs the following in `/usr/local/bin/`:

```sh
#!/bin/sh
[ -e /pentest/intelligence-gathering/dirsearch/dirsearch.py ] || chmod +x /pentest/intelligence-gathering/dirsearch/dirsearch.py
/pentest/intelligence-gathering/dirsearch/dirsearch.py $*
```