### PR TITLE
Added INCLUDE_ONLY_THESE_MODULES config option, added -y option to force install w/o prompt

### DIFF
--- a/ptf
+++ b/ptf
@@ -68,7 +68,10 @@ try:
 
     # if we want to skip going into module
     if  "--update-all" in sys.argv[1:]:
-        src.framework.handle_prompt("use modules/install_update_all")
+        if "-y" in sys.argv[1:]:
+            src.framework.handle_prompt("use modules/install_update_all", True)
+        else:
+            src.framework.handle_prompt("use modules/install_update_all")
     elif "--update-installed" in sys.argv[1:]:
         src.framework.handle_prompt("use modules/update_installed")
     else:

--- a/src/framework.py
+++ b/src/framework.py
@@ -74,6 +74,38 @@ def ignore_module(module):
 
     return result
 
+include_these = []
+if check_config("INCLUDE_ONLY_THESE_MODULES") is not None:
+    include_these = check_config("INCLUDE_ONLY_THESE_MODULES").split(",")
+    if include_these[0] != "":
+        if include_these[0] != '"':
+            print_info("Including only the following modules: " +
+                       (", ").join(include_these))
+        else:
+            include_these = []
+    else:
+        include_these = []
+
+# include only particular modules if they are specified in the ptf.config
+
+
+def include_module(module):
+    if not include_these:
+        return True
+
+    result = False
+    for check in include_these:
+        if "/*" in check:
+            if check[:-1] in module:
+                result = True
+        else:
+            if (os.getcwd() + "/" + check + ".py") == module:
+                result = True
+    if result:
+        print_status("Including module: " + module)
+
+    return result
+
 # check the folder structure
 
 
@@ -570,7 +602,8 @@ def handle_prompt(prompt, force=False):
                             # join the structure
                         filename = os.path.join(path, name)
                         # strip un-needed files
-                        if not "__init__.py" in filename and not ignore_module(filename) and ".py" in filename and not ".pyc" in filename:
+                        if not "__init__.py" in filename and not ignore_module(filename) and include_module(filename) and ".py" in filename and not ".pyc" in filename:
+                            print("!!!***!!!installing deps for module: " + filename)
                             # shorten it up a little bit
                             filename_short = filename.replace(
                                 os.getcwd() + "/", "")
@@ -640,7 +673,7 @@ def handle_prompt(prompt, force=False):
                     for name in files:
                         # join the structure
                         filename = os.path.join(path, name)
-                        if not "__init__.py" in filename and not ignore_module(filename) and ".py" in filename and not ".pyc" in filename and not "install_update_all" in filename and not "__init__" in filename:
+                        if not "__init__.py" in filename and not ignore_module(filename) and include_module(filename) and ".py" in filename and not ".pyc" in filename and not "install_update_all" in filename and not "__init__" in filename:
                             # strip un-needed files
                             # if not "__init__.py" in filename and not ignore_module(filename):
                             # shorten it up a little bit

--- a/src/framework.py
+++ b/src/framework.py
@@ -539,7 +539,7 @@ def handle_prompt(prompt, force=False):
                     install_query = input(
                         "[*] You are about to install/update everything. Proceed? [yes/no]:")
                 else:
-                    print "[*] You are about to install/update everything. Proceed? [yes/no]:yes"
+                    print("[*] You are about to install/update everything. Proceed? [yes/no]:yes")
                     install_query = "yes"
             except EOFError:
                 install_query = "no"

--- a/src/framework.py
+++ b/src/framework.py
@@ -490,7 +490,7 @@ def find_containing_file(directory, location):
         return None
 
 
-def handle_prompt(prompt):
+def handle_prompt(prompt, force=False):
     # specify no commands, if counter increments then a command was found
     base_counter = 0
 
@@ -535,8 +535,12 @@ def handle_prompt(prompt):
         if "install_update_all" in prompt[1]:
             counter = 3
             try:
-                install_query = input(
-                    "[*] You are about to install/update everything. Proceed? [yes/no]:")
+                if not force:
+                    install_query = input(
+                        "[*] You are about to install/update everything. Proceed? [yes/no]:")
+                else:
+                    print "[*] You are about to install/update everything. Proceed? [yes/no]:yes"
+                    install_query = "yes"
             except EOFError:
                 install_query = "no"
                 print("")


### PR DESCRIPTION
First off, thanks for the great project! Should definitely save some time installing things over and over :)

I had a need to script the install of several modules during a PXE boot. To accomplish this, I added two small features:
* Added "-y" option to force install w/o a prompt. Currently the "--update-all" flag still prompts with a yes/no confirmation, the "-y" option automatically responds yes.
* Added INCLUDE_ONLY_THESE_MODULES config option similar to the IGNORE_THESE_MODULES configuration, but whitelists modules as opposed to blacklisting them. This made it easier for me to choose the modules I wanted to install during a scripted install w/o installing all modules.

These changes have been helpful for me, feel free to take it or leave it!