### PR TITLE
added cd-to-path in LAUNCHER

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -380,7 +380,7 @@ def launcher(filename, install_location):
                 # if we found filetype
                 if point != "":
                     filewrite = open("/usr/local/bin/" + launchers, "w")
-                    filewrite.write('#!/bin/sh\n[ -x %s%s ] || chmod +x %s%s\n%s%s $*\n' %
+                    filewrite.write('#!/bin/sh\n[ -x %s%s ] || chmod +x %s%s\ncd %s\n./%s $*\n' %
                                     (install_location, file_point, install_location, file_point, install_location, file_point))
                     filewrite.close()
                     subprocess.Popen("chmod +x /usr/local/bin/%s" %


### PR DESCRIPTION
maybe it is a good Idea to add a cd-to-the-path to all LAUNCHER-script.
Some tools (setoolkit) work only fine if located at the original intended place (/usr/share/setoolkit)
or
if started from within the new directory (/pentest/exploitation/setoolkit/).
See issue #339.
