### PR TITLE
Update masscan.py: Add clang dependency

### DIFF
--- a/modules/intelligence-gathering/masscan.py
+++ b/modules/intelligence-gathering/masscan.py
@@ -20,7 +20,7 @@ REPOSITORY_LOCATION="https://github.com/robertdavidgraham/masscan.git"
 INSTALL_LOCATION="masscan"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="git,gcc,make,libpcap-dev"
+DEBIAN="git,gcc,make,libpcap-dev,clang"
 
 # DEPENDS FOR FEDORA INSTALLS
 FEDORA="git,gcc,make,libpcap-devel"


### PR DESCRIPTION
On a fresh Debian 9.3 VPS without this dependency:

```
[*] Sending after command: make -j
clang -g -ggdb    -Wall -O3 -c src/crypto-base64.c -o tmp/crypto-base64.o
clang -g -ggdb    -Wall -O3 -c src/crypto-blackrock2.c -o tmp/crypto-blackrock2.o
clang -g -ggdb    -Wall -O3 -c src/event-timeout.c -o tmp/event-timeout.o
clang -g -ggdb    -Wall -O3 -c src/in-binary.c -o tmp/in-binary.o
clang -g -ggdb    -Wall -O3 -c src/in-filter.c -o tmp/in-filter.o
clang -g -ggdb    -Wall -O3 -c src/in-report.c -o tmp/in-report.o
make: clang: Command not found
make: clang: Command not found
make: clang: Command not found
make: clang: Command not found
make: clang: Command not found
Makefile:87: recipe for target 'tmp/crypto-base64.o' failed
make: *** [tmp/crypto-base64.o] Error 127
make: *** Waiting for unfinished jobs....
Makefile:87: recipe for target 'tmp/crypto-blackrock2.o' failed
make: *** [tmp/crypto-blackrock2.o] Error 127
Makefile:87: recipe for target 'tmp/event-timeout.o' failed
make: *** [tmp/event-timeout.o] Error 127
Makefile:87: recipe for target 'tmp/in-binary.o' failed
make: *** [tmp/in-binary.o] Error 127
Makefile:87: recipe for target 'tmp/in-filter.o' failed
make: *** [tmp/in-filter.o] Error 127
make: clang: Command not found
Makefile:87: recipe for target 'tmp/in-report.o' failed
make: *** [tmp/in-report.o] Error 127
[*] Sending after command: cp bin/masscan .
cp: cannot stat 'bin/masscan': No such file or directory
[*] Completed running after commands routine..
[*] Running updatedb to tidy everything up.
```