### PR TITLE
Added config item to ignore organizational directories.

### DIFF
--- a/config/ptf.config
+++ b/config/ptf.config
@@ -5,6 +5,9 @@
 ### This is the base directory where PTF will install the files
 BASE_INSTALL_PATH="/pentest"
 
+### Place tools in organizational directories (e.g. exploitation, intelligence-gathering, etc). If set to "False", all tools will be installed in the BASE_INSTALL_PATH
+USE_DIRECTORY_ORGANIZATION="True"
+
 ### Specify the output log file
 LOG_PATH="src/logs/ptf.log"
 

--- a/src/framework.py
+++ b/src/framework.py
@@ -218,11 +218,22 @@ def use_module(module, all_trigger):
 
             # grab install path
             base_install = check_config("BASE_INSTALL_PATH=")
+            strorganize_dirs = check_config("USE_DIRECTORY_ORGANIZATION=")
             install_base_location = module_parser(filename, "INSTALL_LOCATION")
             module_split = module.split("/")
             module_split = module_split[1]
-            install_location = os.path.expanduser(base_install + "/" + \
-                module_split + "/" + install_base_location + "/")
+
+            if strorganize_dirs == "False":
+                organize_dirs = False
+            else:
+                # Default to True
+                organize_dirs = True
+
+            if bool(organize_dirs) == True:
+                install_location = os.path.expanduser(base_install + "/" + \
+                    module_split + "/" + install_base_location + "/")
+            else:
+                install_location = base_install + "/" + install_base_location + "/"
 
 
         while 1:


### PR DESCRIPTION
Simple feature to allow users to ignore the automatic usage of organizational directories such as "exploitation" or "intelligence-gathering" and install all tools to the base install path. Preferable for those who like seeing all their tools in the same directory.

Tested both conditions as well as various install directories. The default option is True, meaning if the user misspells "False" in any way, ptf will default to using organizational directories.