### PR TITLE
Typo in ScanCannon Description

### DIFF
--- a/modules/intelligence-gathering/scancannon.py
+++ b/modules/intelligence-gathering/scancannon.py
@@ -7,7 +7,7 @@
 AUTHOR="Dave Kennedy (ReL1K)"
 
 # DESCRIPTION OF THE MODULE
-DESCRIPTION="This module will install/update ScanScannon - features of masscan and nmap combined (need to install masscan module first)"
+DESCRIPTION="This module will install/update ScanCannon - features of masscan and nmap combined (need to install masscan module first)"
 
 # INSTALL TYPE GIT, SVN, FILE DOWNLOAD
 # OPTIONS = GIT, SVN, FILE


### PR DESCRIPTION
Originally said ScanScannon. Fixed to be ScanCannon