### PR TITLE
Fixed dependencies to install lxml

### DIFF
--- a/modules/intelligence-gathering/dnsrecon.py
+++ b/modules/intelligence-gathering/dnsrecon.py
@@ -20,13 +20,13 @@ REPOSITORY_LOCATION="https://github.com/darkoperator/dnsrecon"
 INSTALL_LOCATION="dnsrecon"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="git,python-dnspython,python-netaddr"
+DEBIAN="git,python-pip"
 
 # DEPENDS FOR FEDORA INSTALLS
-FEDORA="git,python-dns,python-netaddr"
+FEDORA="git,python-pip"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS=""
+AFTER_COMMANDS="cd {INSTALL_LOCATION},pip install -r requirements.txt"
 
 # CREATE LAUNCHER
 LAUNCHER="dnsrecon"


### PR DESCRIPTION
I removed dependency installs to instead use pip and the requirements.txt file of dnsrecon since that includes the two dependencies already and lxml (which was missing). The lxml install could be added to the module files dependencies, but using the projects requirements.txt file seemed the cleaner and more easily maintained method.