### PR TITLE
fix issue 419: pull from mubix repo instead of bidord

### DIFF
--- a/modules/post-exploitation/pykek.py
+++ b/modules/post-exploitation/pykek.py
@@ -14,7 +14,7 @@ DESCRIPTION="This module will install/update PyKEK - Kerberos exploitation kit"
 INSTALL_TYPE="GIT"
 
 # LOCATION OF THE FILE OR GIT/SVN REPOSITORY
-REPOSITORY_LOCATION="https://github.com/bidord/pykek"
+REPOSITORY_LOCATION="https://github.com/mubix/pykek"
 
 # WHERE DO YOU WANT TO INSTALL IT
 INSTALL_LOCATION="pykek"


### PR DESCRIPTION
https://github.com/bidord/pykek no longer exists, but the same package seems to be mirrored at https://github.com/mubix/pykek, allowing for a one-line fix.