### PR TITLE
Add curl redirect argument in framework

### DIFF
--- a/src/framework.py
+++ b/src/framework.py
@@ -500,7 +500,7 @@ def use_module(module, all_trigger):
                         print_status(
                             "FILE was the selected method for installation... Using curl -o to install.")
                         repository_file = repository_location.split("/")[-1]
-                        proc = subprocess.Popen('curl -k -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.112 Safari/534.30" -o %s%s %s' % (
+                        proc = subprocess.Popen('curl -k -L -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.112 Safari/534.30" -o %s%s %s' % (
                             install_location, repository_file, repository_location), stderr=subprocess.PIPE, shell=True).wait()
                         print_status(
                             "Finished Installing! Enjoy the tool located under: " + install_location)


### PR DESCRIPTION
Discovered modules using curl would fail to install if the URL provided to download was a redirect.  Adds the -L flag to curl to follow redirects.  Tested on modules/code-audit/splint.