### PR TITLE
Fix shellter.py: Include wine on Debian-based systems

### DIFF
--- a/modules/av-bypass/shellter.py
+++ b/modules/av-bypass/shellter.py
@@ -20,7 +20,7 @@ REPOSITORY_LOCATION="https://www.shellterproject.com/Downloads/Shellter/Latest/s
 INSTALL_LOCATION="shellter"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="wine,curl"
+DEBIAN="wine-development,curl"
 
 # DEPENDS FOR FEDORA INSTALLS
 FEDORA="wine,curl"
@@ -29,7 +29,7 @@ FEDORA="wine,curl"
 BYPASS_UPDATE="YES"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},unzip -j -o shellter.zip,rm shellter.zip,echo '#/bin/sh' > shellter.sh,echo 'wine shellter.exe' >> shellter.sh,chmod +x shellter.sh"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},unzip -j -o shellter.zip,rm shellter.zip,echo '#/bin/sh' > shellter,echo 'wine shellter.exe' >> shellter,chmod +x shellter"
 
 # THIS WILL CREATE AN AUTOMATIC LAUNCHER FOR THE TOOL
 LAUNCHER="shellter"

--- a/modules/av-bypass/shellter.py
+++ b/modules/av-bypass/shellter.py
@@ -29,7 +29,7 @@ FEDORA="wine,curl"
 BYPASS_UPDATE="YES"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},unzip -j -o shellter.zip,rm shellter.zip,echo '#/bin/sh' > shellter,echo 'wine shellter.exe' >> shellter,chmod +x shellter"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},unzip -j -o shellter.zip,rm shellter.zip,echo '#/bin/sh' > shellter,echo pushd {INSTALL_LOCATION} >> shellter,echo 'wine shellter.exe' >> shellter,echo popd >>shellter,chmod +x shellter"
 
 # THIS WILL CREATE AN AUTOMATIC LAUNCHER FOR THE TOOL
 LAUNCHER="shellter"


### PR DESCRIPTION
```
jeff@blue:/pentest/av-bypass/shellter$ sudo apt install wine
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Package wine is a virtual package provided by:
  wine-stable 3.0-1ubuntu1
  wine-development 3.6-1
You should explicitly select one to install.

E: Package 'wine' has no installation candidate
```

Also fix launcher - wrapper script didn't match launcher name.