### PR TITLE
Updated bootstrap.sh to fix failed package installation

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,7 @@
 echo "docker-ptf" > /etc/hostname
 apt-get update
 apt-get upgrade -y
-apt-get install -y python git sudo locate vim pip tcpdump net-tools #libgmp3-dev:i386
+apt-get install -y python git sudo locate vim python-pip wget tcpdump net-tools #libgmp3-dev:i386
 cd /tmp
 wget http://http.kali.org/pool/main/u/unicornscan/unicornscan_0.4.7-1kali2_amd64.deb
 dpkg -i ./unicornscan_0.4.7-1kali2_amd64.deb

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,8 @@
 echo "docker-ptf" > /etc/hostname
 apt-get update
 apt-get upgrade -y
-apt-get install -y python git sudo locate vim python-pip wget tcpdump net-tools #libgmp3-dev:i386
+apt-get install -y python python3 git sudo locate vim python-pip python3-pip flex wget tcpdump net-tools #libgmp3-dev:i386
+apt --fix-broken install -y
 cd /tmp
 wget http://http.kali.org/pool/main/u/unicornscan/unicornscan_0.4.7-1kali2_amd64.deb
 dpkg -i ./unicornscan_0.4.7-1kali2_amd64.deb


### PR DESCRIPTION
The Docker build would complete with errors before packages were installed due to apt-get install missing wget (needed for line 13) and pip should be python-pip.