### PR TITLE
Update WhatWeb gem dependencies

### DIFF
--- a/modules/vulnerability-analysis/whatweb.py
+++ b/modules/vulnerability-analysis/whatweb.py
@@ -26,7 +26,7 @@ DEBIAN="git,ruby,ruby-dev,libruby2.3"
 FEDORA="git,ruby,ruby-dev,rubygems"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},gem install json,gem install rchardet"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},gem install json,gem install ipaddr,gem install addressable"
 
 # ADD LAUNCHER
 LAUNCHER="whatweb"


### PR DESCRIPTION
**I haven't tested this PR.**

This PR updates the `AFTER_COMMANDS` for WhatWeb to install the appropriate dependencies.

WhatWeb version 0.5.0 has been released. The dependencies have changed slightly.

As there are so few dependencies, I opted for the `gem install` approach - but using `bundle install` might be better, as WhatWeb now makes use of a [Gemfile](https://github.com/urbanadventurer/WhatWeb/blob/master/Gemfile).
