### PR TITLE
Fixed a bug where modules wont install on Archlinux

### DIFF
--- a/src/framework.py
+++ b/src/framework.py
@@ -473,9 +473,13 @@ def use_module(module, all_trigger):
                         from src.platforms.archlinux import base_install_modules
                         # grab all the modules we need
                         arch_modules = module_parser(filename, "ARCHLINUX")
-                        base_install_modules(arch_modules)
-                        print_status(
-                            "Pre-reqs for %s have been installed." % (module))
+                        installed = base_install_modules(arch_modules)
+                        if installed:
+                            print_status(
+                                "Pre-reqs for %s have been installed." % (module))
+                        else:
+                            print_status(
+                                "No missing pre-reqs for %s." % (module))
 
                     # if OSTYPE is FEDORA
                     if ostype == "FEDORA":

--- a/src/platforms/archlinux.py
+++ b/src/platforms/archlinux.py
@@ -12,5 +12,8 @@ def base_install_modules(module_name):
 
     # will work for 1 or more space- or comma-separated modules
     modules = module_name.replace(",", " ")
-    command = "pacman -S --needed --noconfirm " + modules
-    subprocess.Popen(command, shell=True).wait()
+    if modules:
+        command = "pacman -S --needed --noconfirm " + modules
+        subprocess.Popen(command, shell=True).wait()
+        return True
+    return False


### PR DESCRIPTION
I ran into an issue while trying to install modules on Arch Linux
```
❯ uname -r
5.4.1-arch1-1
```
## The issue

When installing modules on Arch Linux (tested with `nmap` & `wfuzz`) 

## Reproduce 

[Live Demo](https://asciinema.org/a/3jr8bIhxBVrtnXlqR1113pVJG)

-  On Arch Linux clone the repo and `cd ptf`
-  Start ptf  `sudo ./ptf`
-  Use the `nmap` module 
  ```
  ptf>  use modules/vulnerability-analysis/nmap
  ```
-  Try to install it
  ```
  ptf:(modules/vulnerability-analysis/nmap)>install
  ```
-  Output
  ```
  Preparing dependencies for module: modules/vulnerability-analysis/nmap
error: no targets specified (use -h for help)
[*] Pre-reqs for modules/vulnerability-analysis/nmap have been installed.
[*] Making the appropriate directory structure first
[*] SVN was the selected method for installation... Using SVN to install.
[*] Finished Installing! Enjoy the tool located under: /pentest/vulnerability-analysis/nmap/
[*] Running after commands for post installation requirements.
[*] Sending after command: cd /pentest/vulnerability-analysis/nmap/
[*] Sending after command: ./configure
/bin/sh: ./configure: No such file or directory
[*] Sending after command: make -j4
make: *** No targets specified and no makefile found.  Stop.
[*] Sending after command: make install
make: *** No rule to make target 'install'.  Stop.
[*] Sending after command: cd /pentest/vulnerability-analysis/nmap//ncat
[*] Sending after command: ./configure
/bin/sh: ./configure: No such file or directory
[*] Sending after command: make -j4
make: *** No targets specified and no makefile found.  Stop.
[*] Sending after command: make install
make: *** No rule to make target 'install'.  Stop.
[*] Completed running after commands routine..
[*] Running updatedb to tidy everything up.
```
If you notice `pacman` failed with the error
```
error: no targets specified (use -h for help)
```
and that caused `namp` to not be installed by `ptf`

```
/bin/sh: ./configure: No such file or directory
```

The issue resides in `ptf/src/platforms/archlinux.py`
```python
13   │     # will work for 1 or more space- or comma-separated modules
14   │     modules = module_name.replace(",", " ")
15   │     command = "pacman -S --needed --noconfirm " + modules
16   │     subprocess.Popen(command, shell=True).wait()
```
## Explanation 

When there is no per-requisites for a package or if they are already satisfied the command that gets executed results in an error

```
❯ pacman -S --needed --noconfirm
error: you cannot perform this operation unless you are root.
```

## The fix

To fix this issue i edited `ptf/src/platforms/archlinux.py` and added an if statement

```python
# will work for 1 or more space- or comma-separated modules
  14   │     modules = module_name.replace(",", " ")
  15   │     if modules:
  16   │         command = "pacman -S --needed --noconfirm " + modules
  17   │         subprocess.Popen(command, shell=True).wait()
  18   │         return True
  19   │     return False
```
And modified  'ptf/src/framework.py' to print the appropriate status 

```python
# grab all the modules we need
 475   │                         arch_modules = module_parser(filename, "ARCHLINUX")
 476   │                         installed = base_install_modules(arch_modules)
 477   │                         if installed:
 478   │                             print_status(
 479   │                                 "Pre-reqs for %s have been installed." % (module))
 480   │                         else:
 481   │                             print_status(
 482   │                                 "No missing pre-reqs for %s." % (module))
 483   │ 
```

([Live Demo](https://asciinema.org/a/u7BfUwAhcJcuJy9gwwSseACdt) after applying the fix) 