### PR TITLE
Decrease installation size with git, by cloning latest commit only

### DIFF
--- a/src/framework.py
+++ b/src/framework.py
@@ -550,12 +550,12 @@ def use_module(module, all_trigger):
                             print_status("Installing now.. be patient...")
                             if install_type.lower() == "gitlab":
                                 get_password_gitlab()
-                                proc = pexpect.spawn('git clone %s %s' % (repository_location, install_location))
+                                proc = pexpect.spawn('git clone --depth=1 %s %s' % (repository_location, install_location))
                                 proc.expect('passphrase')
                                 proc.sendline('%s' % password_gitlab)
                                 proc.expect(pexpect.EOF)
                             else:
-                                subprocess.Popen("git clone %s %s" % (repository_location, install_location), stdin=subprocess.PIPE, stderr=subprocess.PIPE, shell=True).wait()
+                                subprocess.Popen("git clone --depth=1 %s %s" % (repository_location, install_location), stdin=subprocess.PIPE, stderr=subprocess.PIPE, shell=True).wait()
 
                             print_status("Finished Installing! Enjoy the tool located under: " + install_location)
                         after_commands(filename, install_location)


### PR DESCRIPTION
This will reduce the size of cloned repositories, by using the parameter `--depth=1` with git. This will allow us to clone only the latest commit. We can also do a pull later without any problem.

This is related to issue #515 

# How did I test this feature
I tested the following things :
  - The parameter `--depth` exists in git version available in _Ubuntu 16.04_, _Fedora 29_, _CentoOS 6_.
  - I tested the program with three modules : `nikto`, `radare2`, `enum4linux` on _Ubuntu 18.04_