### PR TITLE
Update 'sublist3r' installation procedure to use 'python3'

### DIFF
--- a/modules/intelligence-gathering/sublist3r.py
+++ b/modules/intelligence-gathering/sublist3r.py
@@ -20,13 +20,13 @@ REPOSITORY_LOCATION="https://github.com/aboul3la/Sublist3r"
 INSTALL_LOCATION="sublist3r"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="git,python-pip"
+DEBIAN="git,python3-pip"
 
 # DEPENDS FOR FEDORA INSTALLS
-FEDORA="git,python-pip"
+FEDORA="git,python3-pip"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION}, pip install -r requirements.txt"
+AFTER_COMMANDS="cd {INSTALL_LOCATION}, python3 -m pip install -r requirements.txt"
 
 # CREATE LAUNCHER
 LAUNCHER="sublist3r"


### PR DESCRIPTION
Update `sublist3r` installation procedure to use `python3`. Because `python2` has reached EOL (End Of Life).