### PR TITLE
Update nikto.py

### DIFF
--- a/modules/vulnerability-analysis/nikto.py
+++ b/modules/vulnerability-analysis/nikto.py
@@ -20,7 +20,7 @@ REPOSITORY_LOCATION="https://github.com/sullo/nikto"
 INSTALL_LOCATION="nikto"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="perl,libnet-ssleay-perl"
+DEBIAN="perl,libnet-ssleay-perl, gcc, libffi-dev"
 
 # DEPENDS FOR FEDORA INSTALLS
 FEDORA="git,perl,perl-Net-SSLeay"


### PR DESCRIPTION
Install fails on fresh ubuntu 20.04 install - missing gcc and libffi-dev needed to compile nikto. I added them to the depends.