### PR TITLE
build gobuster from source instead of using `go get`

### DIFF
--- a/modules/intelligence-gathering/gobuster.py
+++ b/modules/intelligence-gathering/gobuster.py
@@ -4,7 +4,7 @@
 ####################################
 
 # AUTHOR OF MODULE NAME
-AUTHOR="Zawadi Done"
+AUTHOR="Zawadi Done, Suksit Sripitchayaphan"
 
 # DESCRIPTION OF THE MODULE
 DESCRIPTION="This module will install/update GoBuster"
@@ -19,7 +19,10 @@ REPOSITORY_LOCATION="https://github.com/OJ/gobuster"
 INSTALL_LOCATION="gobuster"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="golang"
+DEBIAN="git,golang"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="echo '\nexport GOPATH=$HOME/go' >> ~/.profile, . ~/.profile,go get github.com/OJ/gobuster,cp ~/go/bin/gobuster /usr/local/bin"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},go get,go build"
+
+# THIS WILL CREATE AN AUTOMATIC LAUNCHER FOR THE TOOL
+LAUNCHER="gobuster"

--- a/modules/reversing/binwalk.py
+++ b/modules/reversing/binwalk.py
@@ -26,8 +26,7 @@ DEBIAN="git,python-lzma"
 FEDORA="git"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},python setup.py install --prefix={INSTALL_LOCATION},cp bin/binwalk ./"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},python3 setup.py install --prefix={INSTALL_LOCATION},cp bin/binwalk ./"
 
 # THIS WILL CREATE AN AUTOMATIC LAUNCHER FOR THE TOOL
 LAUNCHER="binwalk"
-

--- a/modules/reversing/binwalk.py
+++ b/modules/reversing/binwalk.py
@@ -26,7 +26,4 @@ DEBIAN="git,python-lzma"
 FEDORA="git"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},python3 setup.py install --prefix={INSTALL_LOCATION},cp bin/binwalk ./"
-
-# THIS WILL CREATE AN AUTOMATIC LAUNCHER FOR THE TOOL
-LAUNCHER="binwalk"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},python3 setup.py install --prefix=/usr/local"


### PR DESCRIPTION
Installing gobuster from original script always results with gobuster 2.0.1 instead of the latest version (currently 3.1.0)

The original script doesn't make sense anyway because it pulls the code from git and then use `go get` to fetch the binary. This should be the proper way to do it IMO.