### PR TITLE
build from source instead of using `go get`

### DIFF
--- a/modules/intelligence-gathering/gobuster.py
+++ b/modules/intelligence-gathering/gobuster.py
@@ -19,7 +19,10 @@ REPOSITORY_LOCATION="https://github.com/OJ/gobuster"
 INSTALL_LOCATION="gobuster"
 
 # DEPENDS FOR DEBIAN INSTALLS
-DEBIAN="golang"
+DEBIAN="git,golang"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="echo '\nexport GOPATH=$HOME/go' >> ~/.profile, . ~/.profile,go get github.com/OJ/gobuster,cp ~/go/bin/gobuster /usr/local/bin"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},go get,go build"
+
+# THIS WILL CREATE AN AUTOMATIC LAUNCHER FOR THE TOOL
+LAUNCHER="gobuster"


### PR DESCRIPTION
Installing gobuster from original script always results with gobuster 2.0.1 instead of the latest version (currently 3.1.0)

The original script doesn't make sense anyway because it pulls the code from git and then use go get to fetch the binary. This should be the proper way to do it IMO.