### PR TITLE
Update binwalk module

### DIFF
--- a/modules/reversing/binwalk.py
+++ b/modules/reversing/binwalk.py
@@ -26,8 +26,7 @@ DEBIAN="git,python-lzma"
 FEDORA="git"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},python setup.py install --prefix={INSTALL_LOCATION},cp bin/binwalk ./"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},python3 setup.py install --prefix={INSTALL_LOCATION},cp bin/binwalk ./"
 
 # THIS WILL CREATE AN AUTOMATIC LAUNCHER FOR THE TOOL
 LAUNCHER="binwalk"
-

--- a/modules/reversing/binwalk.py
+++ b/modules/reversing/binwalk.py
@@ -26,7 +26,4 @@ DEBIAN="git,python-lzma"
 FEDORA="git"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},python3 setup.py install --prefix={INSTALL_LOCATION},cp bin/binwalk ./"
-
-# THIS WILL CREATE AN AUTOMATIC LAUNCHER FOR THE TOOL
-LAUNCHER="binwalk"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},python3 setup.py install --prefix=/usr/local"


### PR DESCRIPTION
* Use `python3` instead of `python` according to [binwalk documentation](https://github.com/ReFirmLabs/binwalk/blob/master/INSTALL.md)
* Change install prefix to `/usr/local` because `setup.py` should install the package code into standard location (`/usr/local/lib/pythonX.Y/site-packages`), not `{INSTALL_LOCATION}/lib/pythonX.Y/site-packages`. Otherwise we will get errors about "package not found" when running `binwalk`
* Remove LAUNCHER config since the executable will be properly placed at `/usr/local/bin/binwalk` according to the new install prefix