### PR TITLE
crackmapexec: Stop hardcoding exact Python3 version

### DIFF
--- a/modules/post-exploitation/crackmapexec.py
+++ b/modules/post-exploitation/crackmapexec.py
@@ -26,7 +26,7 @@ DEBIAN="python3.7"
 FEDORA="git"
 
 # COMMANDS TO RUN AFTER
-AFTER_COMMANDS="cd {INSTALL_LOCATION},rm -rf crackmapexec,git clone --recursive https://github.com/byt3bl33d3r/CrackMapExec crackmapexec,cd {INSTALL_LOCATION}crackmapexec,python3.7 -m pip install -r requirements.txt,python3.7 setup.py install"
+AFTER_COMMANDS="cd {INSTALL_LOCATION},rm -rf crackmapexec,git clone --recursive https://github.com/byt3bl33d3r/CrackMapExec crackmapexec,cd {INSTALL_LOCATION}crackmapexec,python3 -m pip install -r requirements.txt,python3 setup.py install"
 
 # AUTOMATIC LAUNCH
 LAUNCHER="crackmapexec"


### PR DESCRIPTION
python3.7 is for Debian 10, the now-stable Debian 11 uses python3.9 instead. Use `python3` as the package and command name to avoid breaking newer Debian builds.

https://wiki.debian.org/Python
https://packages.debian.org/search?suite=all&section=all&arch=any&searchon=names&keywords=python3