### PR TITLE
Move to apt-fast if available on Debian and derivates

### DIFF
--- a/src/platforms/debian.py
+++ b/src/platforms/debian.py
@@ -24,9 +24,13 @@ def base_install_modules(module_name):
     # depends
     if counter == 1:
         for module in modules:
-            command = ("apt-get -q --allow-downgrades --allow-remove-essential --allow-change-held-packages -y install " + module)
+            # Check if `apt-fast` is available, otherwise use apt-get
+            if subprocess.Popen("which apt-fast >/dev/null", shell=True).wait() == 0:
+                command = ("apt-fast -y install " + module)
+            else:
+                command = ("apt-get -q --allow-downgrades --allow-remove-essential --allow-change-held-packages -y install " + module)
             subprocess.Popen("export DEBIAN_FRONTEND=noninteractive;%s" %
-                             command, shell=True).wait()
+                            command, shell=True).wait()
     else:
         command = ("apt-get -q --allow-downgrades --allow-remove-essential --allow-change-held-packages -y install " + modules)
         subprocess.Popen("export DEBIAN_FRONTEND=noninteractive;%s" %


### PR DESCRIPTION
In a full VM build this step by itself saved ten minutes. John the Ripper has a lot of dependencies. Moving from ~20 megabits to ~400 megabits in download speeds is satisfying to watch.