### PR TITLE
Update Python_tests.yml: Remove deprecated 2.7 and 3.5

### DIFF
--- a/.github/workflows/Python_tests.yml
+++ b/.github/workflows/Python_tests.yml
@@ -7,7 +7,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [2.7, 3.6, 3.7, 3.8] # 3.5,
+        python-version: [3.7, 3.8] # 2.7, 3.5, 3.6
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Those versions are removed anyway:

```
Error: Version 2.7 with arch x64 not found
Error: Version 3.6 with arch x64 not found
```