### PR TITLE
Update framework.py: Only add i386 arch to x64 machines

### DIFF
--- a/src/framework.py
+++ b/src/framework.py
@@ -9,6 +9,7 @@ from src.core import *
 import sys
 import readline
 import os
+import platform
 import time
 import getpass
 from src.ptflogger import info, error, log
@@ -48,7 +49,7 @@ else: os_profile = profile_os()
 print_status("Operating system detected as: " + bcolors.BOLD + os_profile + bcolors.ENDC)
 
 # main intro here
-if profile_os() == "DEBIAN":
+if profile_os() == "DEBIAN" and platform.machine() == "x86_64":
     subprocess.Popen("sudo dpkg --add-architecture i386", stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True).wait()
 
 print_status("Welcome to PTF - where everything just works...Because.." +


### PR DESCRIPTION
In testing arm64 virtual machines, I was thoroughly confused as to why the i386 architecture kept getting added. This PR will fix it for future folk, as there's no general i386 compatibility layer on Linux for arm64 architecture. This is unlike Windows arm64 builds, which do automatically translate x86 and x64 binaries.